### PR TITLE
Add authenticated prompts management page and CRUD API

### DIFF
--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -14,3 +14,57 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to fetch prompts' }, { status: 500 })
   }
 }
+
+export async function POST(request: Request) {
+  try {
+    const { name, prompt } = await request.json()
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('prompts')
+      .insert({ name, prompt })
+      .select()
+      .single()
+    if (error) {
+      throw error
+    }
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'Failed to create prompt' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { id, name, prompt } = await request.json()
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('prompts')
+      .update({ name, prompt })
+      .eq('id', id)
+      .select()
+      .single()
+    if (error) {
+      throw error
+    }
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'Failed to update prompt' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { id } = await request.json()
+    const supabase = await createClient()
+    const { error } = await supabase.from('prompts').delete().eq('id', id)
+    if (error) {
+      throw error
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'Failed to delete prompt' }, { status: 500 })
+  }
+}

--- a/src/app/prompts/PromptsManager.tsx
+++ b/src/app/prompts/PromptsManager.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Prompt {
+  id: number
+  name: string
+  prompt: string
+}
+
+export default function PromptsManager({ initialPrompts }: { initialPrompts: Prompt[] }) {
+  const [prompts, setPrompts] = useState<Prompt[]>(initialPrompts)
+  const [name, setName] = useState('')
+  const [promptText, setPromptText] = useState('')
+
+  const refreshPrompts = async () => {
+    const res = await fetch('/api/prompts')
+    if (res.ok) {
+      const data = await res.json()
+      setPrompts(data)
+    }
+  }
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch('/api/prompts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, prompt: promptText }),
+    })
+    setName('')
+    setPromptText('')
+    refreshPrompts()
+  }
+
+  const handleUpdate = async (p: Prompt) => {
+    await fetch('/api/prompts', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(p),
+    })
+    refreshPrompts()
+  }
+
+  const handleDelete = async (id: number) => {
+    await fetch('/api/prompts', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    })
+    refreshPrompts()
+  }
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleCreate} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Prompt Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <textarea
+          className="border p-2 w-full"
+          placeholder="Prompt"
+          value={promptText}
+          onChange={(e) => setPromptText(e.target.value)}
+          required
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+          Save
+        </button>
+      </form>
+
+      <ul className="space-y-4">
+        {prompts.map((p) => (
+          <li key={p.id} className="border p-4 space-y-2">
+            <input
+              className="border p-2 w-full"
+              value={p.name}
+              onChange={(e) =>
+                setPrompts((prev) =>
+                  prev.map((item) =>
+                    item.id === p.id ? { ...item, name: e.target.value } : item
+                  )
+                )
+              }
+            />
+            <textarea
+              className="border p-2 w-full"
+              value={p.prompt}
+              onChange={(e) =>
+                setPrompts((prev) =>
+                  prev.map((item) =>
+                    item.id === p.id ? { ...item, prompt: e.target.value } : item
+                  )
+                )
+              }
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="bg-green-600 text-white px-3 py-1 rounded"
+                onClick={() => handleUpdate(p)}
+              >
+                Update
+              </button>
+              <button
+                type="button"
+                className="bg-red-600 text-white px-3 py-1 rounded"
+                onClick={() => handleDelete(p.id)}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -1,0 +1,25 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import PromptsManager from './PromptsManager'
+
+export default async function PromptsPage() {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data?.user) {
+    redirect('/auth/login')
+  }
+
+  // Optional admin-only access
+  if (data.user.user_metadata?.role !== 'admin') {
+    redirect('/')
+  }
+
+  const { data: prompts } = await supabase.from('prompts').select('*')
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Prompts</h1>
+      <PromptsManager initialPrompts={prompts || []} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add POST/PUT/DELETE handlers for `/api/prompts`
- introduce `/prompts` page requiring Supabase auth with optional admin check
- build client-side manager to create, edit, and delete prompts via the API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_68aad2c749c4833394d4178fe62723ac