### PR TITLE
feat: add CRUD handlers for prompts

### DIFF
--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -4,13 +4,12 @@ import { createClient } from '@/lib/supabase/server'
 export async function GET() {
   try {
     const supabase = await createClient()
-    const { data: prompts, error } = await supabase.from('prompts').select('*')
-    if (error) {
-      throw error
-    }
-    return NextResponse.json(prompts)
-  } catch (error) {
-    console.error(error)
+    const { data, error } = await supabase.from('prompts').select('*')
+    if (error) throw error
+
+    return NextResponse.json({ prompts: data }, { status: 200 })
+  } catch (err) {
+    console.error(err)
     return NextResponse.json({ error: 'Failed to fetch prompts' }, { status: 500 })
   }
 }
@@ -18,18 +17,21 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const { name, prompt } = await request.json()
+    if (!name || !prompt) {
+      return NextResponse.json({ error: 'Name and prompt are required' }, { status: 400 })
+    }
+
     const supabase = await createClient()
     const { data, error } = await supabase
       .from('prompts')
       .insert({ name, prompt })
       .select()
       .single()
-    if (error) {
-      throw error
-    }
-    return NextResponse.json(data)
-  } catch (error) {
-    console.error(error)
+    if (error) throw error
+
+    return NextResponse.json({ prompt: data }, { status: 201 })
+  } catch (err) {
+    console.error(err)
     return NextResponse.json({ error: 'Failed to create prompt' }, { status: 500 })
   }
 }
@@ -37,6 +39,10 @@ export async function POST(request: Request) {
 export async function PUT(request: Request) {
   try {
     const { id, name, prompt } = await request.json()
+    if (!id) {
+      return NextResponse.json({ error: 'ID is required' }, { status: 400 })
+    }
+
     const supabase = await createClient()
     const { data, error } = await supabase
       .from('prompts')
@@ -44,12 +50,11 @@ export async function PUT(request: Request) {
       .eq('id', id)
       .select()
       .single()
-    if (error) {
-      throw error
-    }
-    return NextResponse.json(data)
-  } catch (error) {
-    console.error(error)
+    if (error) throw error
+
+    return NextResponse.json({ prompt: data }, { status: 200 })
+  } catch (err) {
+    console.error(err)
     return NextResponse.json({ error: 'Failed to update prompt' }, { status: 500 })
   }
 }
@@ -57,14 +62,17 @@ export async function PUT(request: Request) {
 export async function DELETE(request: Request) {
   try {
     const { id } = await request.json()
+    if (!id) {
+      return NextResponse.json({ error: 'ID is required' }, { status: 400 })
+    }
+
     const supabase = await createClient()
     const { error } = await supabase.from('prompts').delete().eq('id', id)
-    if (error) {
-      throw error
-    }
-    return NextResponse.json({ success: true })
-  } catch (error) {
-    console.error(error)
+    if (error) throw error
+
+    return NextResponse.json({ success: true }, { status: 200 })
+  } catch (err) {
+    console.error(err)
     return NextResponse.json({ error: 'Failed to delete prompt' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- add API route for listing, creating, updating, and deleting prompts
- validate required fields and return appropriate status codes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aad3b5fdc083338b5e1806ec97a813