### PR TITLE
Add global navigation bar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Navbar />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,17 +13,10 @@ export default async function Home() {
 
   return (
     <div className="min-h-screen flex flex-col items-center p-4">
-      <div className="w-full max-w-2xl flex justify-between items-center">
-        <p className="text-sm">Helo, {data.user.email}</p>
-        <form action="/auth/signout" method="post">
-          <button type="submit" className="text-sm bg-gray-600 hover:bg-gray-700 text-white py-1 px-3 rounded">
-            Sign out
-          </button>
-        </form>
-      </div>
-
       <h1 className="text-3xl font-bold mt-8 mb-4">Sosmed Gen</h1>
-      <p className="mb-8">Masukkan niche anda dan pilih gaya penulisan untuk menjana posting media sosial.</p>
+      <p className="mb-8">
+        Masukkan niche anda dan pilih gaya penulisan untuk menjana posting media sosial.
+      </p>
 
       {/* Paparkan Borang Penjana Di Sini */}
       <GeneratorForm />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function Navbar() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <nav className="bg-gray-800 text-white">
+      <div className="max-w-4xl mx-auto flex justify-between items-center p-4">
+        <div className="flex space-x-4">
+          <Link href="/" className="hover:underline">
+            Home
+          </Link>
+          <Link href="/prompts" className="hover:underline">
+            Prompts
+          </Link>
+        </div>
+        <div className="flex items-center space-x-4">
+          {user && <span className="text-sm">Hello, {user.email}</span>}
+          <form action="/auth/signout" method="post">
+            <button
+              type="submit"
+              className="text-sm bg-gray-600 hover:bg-gray-700 py-1 px-3 rounded"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add Tailwind-styled Navbar with Home, Prompts and sign-out links
- render Navbar across all pages
- remove page-specific sign-out block from home page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68aad7f64f0083338e9a4b06625ab056