### PR TITLE
refactor: handle prompts response shape

### DIFF
--- a/src/app/prompts/PromptsManager.tsx
+++ b/src/app/prompts/PromptsManager.tsx
@@ -16,7 +16,7 @@ export default function PromptsManager({ initialPrompts }: { initialPrompts: Pro
   const refreshPrompts = async () => {
     const res = await fetch('/api/prompts')
     if (res.ok) {
-      const data = await res.json()
+      const { prompts: data } = await res.json()
       setPrompts(data)
     }
   }

--- a/src/components/GeneratorForm.tsx
+++ b/src/components/GeneratorForm.tsx
@@ -14,7 +14,7 @@ export default function GeneratorForm() {
   useEffect(() => {
     const fetchPrompts = async () => {
       const res = await fetch('/api/prompts')
-      const data = await res.json()
+      const { prompts: data } = await res.json()
       setPrompts(data)
       if (data.length > 0) {
         setPromptId(data[0].id)


### PR DESCRIPTION
## Summary
- adjust GeneratorForm to read prompts array from API responses
- align PromptsManager refresh logic with prompts response shape

## Testing
- `npm test` *(fails: Missing script: "test"?)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aada04febc833382073f5c98f91c02