### PR TITLE
feat: add transcribe proxy route

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+TRANSCRIBE_API_BASE=https://api-transcribe.yuslabs.xyz

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local
 
 # vercel
 .vercel

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+const BASE_URL = process.env.TRANSCRIBE_API_BASE || 'https://api-transcribe.yuslabs.xyz';
+
+export async function POST(request: Request) {
+  try {
+    const { videoUrl, videoId } = await request.json();
+    const res = await fetch(`${BASE_URL}/api/process-video`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoUrl, videoId }),
+    });
+
+    if (!res.ok) {
+      throw new Error('Failed to start transcription');
+    }
+
+    const data = await res.json();
+    return NextResponse.json({ taskId: data.taskId });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to start transcription' }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const taskId = searchParams.get('taskId');
+
+  if (!taskId) {
+    return NextResponse.json({ error: 'taskId is required' }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(`${BASE_URL}/api/result/${taskId}`);
+    if (!res.ok) {
+      throw new Error('Failed to fetch transcription result');
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to fetch transcription result' }, { status: 500 });
+  }
+}
+

--- a/src/components/GeneratorForm.tsx
+++ b/src/components/GeneratorForm.tsx
@@ -31,7 +31,7 @@ export default function GeneratorForm() {
     if (!taskId) return
     const interval = setInterval(async () => {
       try {
-        const res = await fetch(`https://api-transcribe.yuslabs.xyz/api/result/${taskId}`)
+        const res = await fetch(`/api/transcribe?taskId=${taskId}`)
         const data = await res.json()
         if (data.status === 'completed') {
           setSummary(data.summary)
@@ -80,7 +80,7 @@ export default function GeneratorForm() {
     setSummary('')
 
     try {
-      const response = await fetch('https://api-transcribe.yuslabs.xyz/api/process-video', {
+      const response = await fetch('/api/transcribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ videoUrl, videoId }),


### PR DESCRIPTION
## Summary
- proxy transcription POST/GET requests through new `/api/transcribe` route
- call the internal proxy from `GeneratorForm` instead of hitting remote API directly
- document `TRANSCRIBE_API_BASE` in `.env.local` for configurable endpoint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac72d736c883338f4df4dab53f981f