### PR TITLE
Derive YouTube video ID from URL and simplify transcription flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Replace the URL if you host your own transcription API.
 
 ### Workflow
 
-1. Enter a YouTube URL and its corresponding video ID in the generator form.
+1. Enter a YouTube URL in the generator form. The video ID is extracted automatically.
 2. Submit the form to start a background transcription job. The server returns a `taskId`.
 3. The client polls the transcription endpoint every 3 seconds until the job finishes.
 4. Once transcription completes, the summary feeds the post generator and a styled post appears in the UI for editing or copying.


### PR DESCRIPTION
## Summary
- Remove manual YouTube ID input and parse the ID directly from the provided URL.
- Update transcription API route to compute video ID internally from the URL.
- Adjust documentation to reflect automatic video ID extraction.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68adafdd100083338bbde16319597954