### PR TITLE
Expose upstream transcription errors

### DIFF
--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -39,7 +39,9 @@ export async function POST(request: Request) {
     });
 
     if (!res.ok) {
-      throw new Error('Failed to start transcription');
+      const message = await res.text();
+      console.error(message);
+      return NextResponse.json({ error: message }, { status: res.status });
     }
 
     const data = await res.json();


### PR DESCRIPTION
## Summary
- return upstream error message when starting a transcription fails

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add40c624483339d28c30c442a2a3a