### PR TITLE
Remove GET rate limit for transcription polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Replace the URL if you host your own transcription API.
 
 ## Rate Limiting
 
-The `/api/generate` and `/api/transcribe` endpoints are protected by an in-memory token bucket limiter allowing up to **10 requests per minute per IP address**. Requests above this threshold return `429 Too Many Requests` and are not forwarded to external services.
+POST requests to the `/api/generate` and `/api/transcribe` endpoints are protected by an in-memory token bucket limiter allowing up to **10 requests per minute per IP address**. Requests above this threshold return `429 Too Many Requests` and are not forwarded to external services.
+
+The GET operation for `/api/transcribe` is not rate limited.
 
 ## Getting Started
 

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -53,15 +53,6 @@ export async function POST(request: Request) {
 }
 
 export async function GET(request: Request) {
-  const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    'unknown';
-  if (!rateLimit(ip)) {
-    return NextResponse.json(
-      { error: 'Too many requests' },
-      { status: 429 },
-    );
-  }
   const { searchParams } = new URL(request.url);
   const taskId = searchParams.get('taskId');
 


### PR DESCRIPTION
## Summary
- drop rate limiting from `GET /api/transcribe` so result polling isn't throttled
- keep rate limiting on expensive POST calls
- document that only POST requests are rate limited

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae928b7ce08333be3b2bd31b78280f