### PR TITLE
Scope rate limiting by HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Replace the URL if you host your own transcription API.
 
 ## Rate Limiting
 
-The `/api/generate` and `/api/transcribe` endpoints are protected by an in-memory token bucket limiter allowing up to **10 requests per minute per IP address**. Requests above this threshold return `429 Too Many Requests` and are not forwarded to external services.
+The `/api/generate` and `/api/transcribe` endpoints are protected by an in-memory token bucket limiter allowing up to **10 requests per minute**. Limits are tracked per IP address **and HTTP method**, so `POST` and `GET` requests are counted separately for each endpoint. Requests above the threshold return `429 Too Many Requests` and are not forwarded to external services.
 
 ## Getting Started
 

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request) {
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
     'unknown';
-  if (!rateLimit(ip)) {
+  if (!rateLimit(request.method, ip)) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429 },

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: Request) {
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
     'unknown';
-  if (!rateLimit(ip)) {
+  if (!rateLimit(request.method, ip)) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429 },
@@ -56,7 +56,7 @@ export async function GET(request: Request) {
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
     'unknown';
-  if (!rateLimit(ip)) {
+  if (!rateLimit(request.method, ip)) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429 },

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -8,9 +8,10 @@ const MAX_TOKENS = 10;
 const REFILL_WINDOW_MS = 60_000; // 1 minute
 const REFILL_RATE = MAX_TOKENS / REFILL_WINDOW_MS; // tokens per ms
 
-export function rateLimit(identifier: string): boolean {
+export function rateLimit(method: string, identifier: string): boolean {
+  const key = `${method}:${identifier}`;
   const now = Date.now();
-  const bucket = buckets.get(identifier) ?? {
+  const bucket = buckets.get(key) ?? {
     tokens: MAX_TOKENS,
     lastRefill: now,
   };
@@ -23,12 +24,12 @@ export function rateLimit(identifier: string): boolean {
   bucket.lastRefill = now;
 
   if (bucket.tokens < 1) {
-    buckets.set(identifier, bucket);
+    buckets.set(key, bucket);
     return false;
   }
 
   bucket.tokens -= 1;
-  buckets.set(identifier, bucket);
+  buckets.set(key, bucket);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- track rate limiting buckets per HTTP method
- update API routes to pass method in identifiers
- document method-specific rate limits

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9290d2848333884d5505d6f486cd