### PR TITLE
docs: clarify rate limit behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Replace the URL if you host your own transcription API.
 
 ## Rate Limiting
 
-The `/api/generate` and `/api/transcribe` endpoints are protected by an in-memory token bucket limiter allowing up to **10 requests per minute per IP address**. Requests above this threshold return `429 Too Many Requests` and are not forwarded to external services.
+Only POST endpoints such as `/api/generate` and `/api/transcribe` are subject to the server's in-memory token bucket limiter. By default each IP may make up to **10 POST requests per minute**; additional POSTs receive `429 Too Many Requests` and are not forwarded to external services.
+
+GET requests are unrestricted unless you assign them their own bucket. For example, you might configure a separate bucket allowing **60 GET requests per minute** so that GET traffic does not consume the POST allocation.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- document that rate limiting now only affects POST requests
- mention default 10/min limit and example separate GET bucket

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9292d17083339e29f5b9b8f0594c