### PR TITLE
feat: persist and manage generated posts

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET() {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase.from('posts').select('*').order('created_at', { ascending: false })
+    if (error) throw error
+    return NextResponse.json({ posts: data }, { status: 200 })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to fetch posts' }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { content, status } = await request.json()
+    if (!content || !status) {
+      return NextResponse.json({ error: 'Content and status are required' }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const { data, error } = await supabase.from('posts').insert({ content, status }).select().single()
+    if (error) throw error
+    return NextResponse.json({ post: data }, { status: 201 })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to create post' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const { id, content, status } = await request.json()
+    if (!id || !content || !status) {
+      return NextResponse.json({ error: 'ID, content, and status are required' }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('posts')
+      .update({ content, status, updated_at: new Date().toISOString() })
+      .eq('id', id)
+      .select()
+      .single()
+    if (error) throw error
+    return NextResponse.json({ post: data }, { status: 200 })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to update post' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const { id } = await request.json()
+    if (!id) {
+      return NextResponse.json({ error: 'ID is required' }, { status: 400 })
+    }
+    const supabase = await createClient()
+    const { error } = await supabase.from('posts').delete().eq('id', id)
+    if (error) throw error
+    return NextResponse.json({ success: true }, { status: 200 })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to delete post' }, { status: 500 })
+  }
+}

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Post = {
+  id: number
+  content: string
+  status: string
+}
+
+export default function PostsPage() {
+  const [posts, setPosts] = useState<Post[]>([])
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editContent, setEditContent] = useState('')
+  const [editStatus, setEditStatus] = useState('draft')
+
+  const fetchPosts = async () => {
+    try {
+      const res = await fetch('/api/posts')
+      const data = await res.json()
+      setPosts(data.posts || [])
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    fetchPosts()
+  }, [])
+
+  const startEditing = (post: Post) => {
+    setEditingId(post.id)
+    setEditContent(post.content)
+    setEditStatus(post.status)
+  }
+
+  const handleUpdate = async (id: number) => {
+    try {
+      const res = await fetch('/api/posts', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, content: editContent, status: editStatus }),
+      })
+      const data = await res.json()
+      setPosts(posts.map((p) => (p.id === id ? data.post : p)))
+      setEditingId(null)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleDelete = async (id: number) => {
+    try {
+      await fetch('/api/posts', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      })
+      setPosts(posts.filter((p) => p.id !== id))
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleCopy = (text: string) => {
+    navigator.clipboard.writeText(text)
+  }
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Posts</h1>
+      {posts.map((post) => (
+        <div key={post.id} className="border p-4 mb-4 rounded">
+          {editingId === post.id ? (
+            <>
+              <textarea
+                className="w-full rounded text-black p-2"
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+              />
+              <select
+                className="mt-2 p-2 rounded text-black"
+                value={editStatus}
+                onChange={(e) => setEditStatus(e.target.value)}
+              >
+                <option value="draft">draft</option>
+                <option value="posted">posted</option>
+              </select>
+              <div className="mt-2 space-x-2">
+                <button
+                  onClick={() => handleUpdate(post.id)}
+                  className="bg-blue-600 text-white px-3 py-1 rounded"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => setEditingId(null)}
+                  className="bg-gray-300 text-black px-3 py-1 rounded"
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="whitespace-pre-wrap">{post.content}</p>
+              <span className="inline-block mt-2 px-2 py-1 text-sm bg-gray-200 rounded">
+                {post.status}
+              </span>
+              <div className="mt-2 space-x-2">
+                <button
+                  onClick={() => startEditing(post)}
+                  className="bg-yellow-500 text-white px-3 py-1 rounded"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDelete(post.id)}
+                  className="bg-red-600 text-white px-3 py-1 rounded"
+                >
+                  Delete
+                </button>
+                <button
+                  onClick={() => handleCopy(post.content)}
+                  className="bg-green-600 text-white px-3 py-1 rounded"
+                >
+                  Copy
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/GeneratorForm.tsx
+++ b/src/components/GeneratorForm.tsx
@@ -76,6 +76,16 @@ export default function GeneratorForm() {
         })
         const data = await response.json()
         setGeneratedPost(data.post)
+
+        try {
+          await fetch('/api/posts', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: data.post, status: 'draft' }),
+          })
+        } catch (err) {
+          console.error(err)
+        }
       } catch (err) {
         console.error(err)
       } finally {

--- a/supabase/migrations/20241107000000_create_posts_table.sql
+++ b/supabase/migrations/20241107000000_create_posts_table.sql
@@ -1,0 +1,7 @@
+create table if not exists posts (
+  id bigint primary key generated always as identity,
+  content text not null,
+  status text not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add `posts` table migration
- implement CRUD API for posts
- persist generated posts and provide page to edit, copy, or delete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9bacb870833389d7143803b2249d