### PR TITLE
feat: always fetch fresh posts

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic'
+
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 


### PR DESCRIPTION
## Summary
- ensure posts API always fetches fresh data by declaring `dynamic = 'force-dynamic'`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afee1fa3848333aa7c04ab7a98575f