### PR TITLE
Refresh posts page after creating new post

### DIFF
--- a/src/components/GeneratorForm.tsx
+++ b/src/components/GeneratorForm.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 function extractVideoId(url: string): string | null {
   try {
@@ -17,6 +18,7 @@ function extractVideoId(url: string): string | null {
 }
 
 export default function GeneratorForm() {
+  const router = useRouter()
   const [videoUrl, setVideoUrl] = useState('')
   const [summary, setSummary] = useState('')
   const [taskId, setTaskId] = useState<string | null>(null)
@@ -78,11 +80,14 @@ export default function GeneratorForm() {
         setGeneratedPost(data.post)
 
         try {
-          await fetch('/api/posts', {
+          const res = await fetch('/api/posts', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ content: data.post, status: 'draft' }),
           })
+          if (res.ok) {
+            router.refresh()
+          }
         } catch (err) {
           console.error(err)
         }
@@ -93,7 +98,7 @@ export default function GeneratorForm() {
       }
     }
     generatePost()
-  }, [summary, promptId])
+  }, [summary, promptId, router])
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()


### PR DESCRIPTION
## Summary
- refresh the router after saving a generated post so the posts page stays up to date

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afee6624488333b6aba72be6c431ac