### PR TITLE
fix: use video_url for tasks

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
     const supabase = await createClient()
     const { data, error } = await supabase
       .from('tasks')
-      .select('id, created_at, video_URL, prompt_id, status, result, summary')
+      .select('id, created_at, video_url, prompt_id, status, result, summary')
       .order('created_at', { ascending: false })
     if (error) throw error
     return NextResponse.json({ tasks: data }, { status: 200 })
@@ -29,7 +29,7 @@ export async function PUT(request: Request) {
       .from('tasks')
       .update({ result, status, updated_at: new Date().toISOString() })
       .eq('id', id)
-      .select('id, created_at, video_URL, prompt_id, status, result, summary, updated_at')
+      .select('id, created_at, video_url, prompt_id, status, result, summary, updated_at')
       .single()
     if (error) throw error
     return NextResponse.json({ task: data }, { status: 200 })

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -5,12 +5,14 @@ import { useEffect, useState } from 'react'
 type Task = {
   id: number
   created_at: string
-  video_URL: string
+  videoUrl: string
   prompt_id: number
   status: string
   result: string
   summary: string
 }
+
+type RawTask = Omit<Task, 'videoUrl'> & { video_url: string }
 
 export default function PostsPage() {
   const [tasks, setTasks] = useState<Task[]>([])
@@ -22,7 +24,11 @@ export default function PostsPage() {
     try {
       const res = await fetch('/api/tasks', { cache: 'no-store' })
       const data = await res.json()
-      setTasks(data.tasks || [])
+      const tasks = (data.tasks || []).map((t: RawTask): Task => ({
+        ...t,
+        videoUrl: t.video_url,
+      }))
+      setTasks(tasks)
     } catch (err) {
       console.error(err)
     }
@@ -72,7 +78,7 @@ export default function PostsPage() {
         <div key={task.id} className="border p-4 mb-4 rounded">
           {editingId === task.id ? (
             <>
-              <p className="break-words">{task.video_URL}</p>
+              <p className="break-words">{task.videoUrl}</p>
               <p className="mt-1">Prompt: {task.prompt_id}</p>
               <textarea
                 className="w-full rounded text-black p-2 mt-2"
@@ -105,7 +111,7 @@ export default function PostsPage() {
             </>
           ) : (
             <>
-              <p className="break-words">{task.video_URL}</p>
+              <p className="break-words">{task.videoUrl}</p>
               <p>Prompt: {task.prompt_id}</p>
               <p className="mt-2 whitespace-pre-wrap">{task.result}</p>
               <span className="inline-block mt-2 px-2 py-1 text-sm bg-gray-200 rounded">

--- a/supabase/migrations/20241108000000_update_tasks_video_url.sql
+++ b/supabase/migrations/20241108000000_update_tasks_video_url.sql
@@ -1,0 +1,2 @@
+-- Rename video_URL to video_url for tasks table
+ALTER TABLE tasks RENAME COLUMN video_URL TO video_url;


### PR DESCRIPTION
## Summary
- use `video_url` column in task API and migration
- map `video_url` from API to `videoUrl` in posts page

## Testing
- `npm run lint`
- `curl http://localhost:3000/api/tasks` *(fails: Failed to fetch tasks)*
- `curl -X PUT http://localhost:3000/api/tasks -d '{"id":1,"result":"test","status":"draft"}'` *(fails: Failed to update task)*


------
https://chatgpt.com/codex/tasks/task_e_68b0151222588333809123a99a2f06ff