### PR TITLE
Improve prompts manager UI with editing and search

### DIFF
--- a/src/app/prompts/PromptsManager.tsx
+++ b/src/app/prompts/PromptsManager.tsx
@@ -12,6 +12,11 @@ export default function PromptsManager({ initialPrompts }: { initialPrompts: Pro
   const [prompts, setPrompts] = useState<Prompt[]>(initialPrompts)
   const [name, setName] = useState('')
   const [promptText, setPromptText] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editTemplate, setEditTemplate] = useState('')
+  const [search, setSearch] = useState('')
 
   const refreshPrompts = async () => {
     const res = await fetch('/api/prompts')
@@ -30,16 +35,25 @@ export default function PromptsManager({ initialPrompts }: { initialPrompts: Pro
     })
     setName('')
     setPromptText('')
+    setIsCreating(false)
     refreshPrompts()
   }
 
-  const handleUpdate = async (p: Prompt) => {
-    const { id, name, template } = p
+  const startEdit = (p: Prompt) => {
+    setEditingId(p.id)
+    setEditName(p.name)
+    setEditTemplate(p.template)
+  }
+
+  const handleEditSave = async (id: number) => {
     await fetch('/api/prompts', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, name, template }),
+      body: JSON.stringify({ id, name: editName, template: editTemplate }),
     })
+    setEditingId(null)
+    setEditName('')
+    setEditTemplate('')
     refreshPrompts()
   }
 
@@ -52,69 +66,131 @@ export default function PromptsManager({ initialPrompts }: { initialPrompts: Pro
     refreshPrompts()
   }
 
+  const truncate = (str: string, max = 80) =>
+    str.length > max ? `${str.slice(0, max)}...` : str
+
+  const filteredPrompts = prompts.filter((p) => {
+    const term = search.toLowerCase()
+    return (
+      p.name.toLowerCase().includes(term) ||
+      p.template.toLowerCase().includes(term)
+    )
+  })
+
   return (
     <div className="space-y-6">
-      <form onSubmit={handleCreate} className="space-y-2">
+      <div className="flex items-center gap-4">
         <input
-          className="border p-2 w-full"
-          placeholder="Template Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
+          className="border p-2 flex-1"
+          placeholder="Search prompts..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
         />
-        <textarea
-          className="border p-2 w-full"
-          placeholder="Template"
-          value={promptText}
-          onChange={(e) => setPromptText(e.target.value)}
-          required
-        />
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
-          Save
+        <button
+          type="button"
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          onClick={() => setIsCreating(true)}
+        >
+          Create Prompt
         </button>
-      </form>
+      </div>
+
+      {isCreating && (
+        <form onSubmit={handleCreate} className="space-y-2 border p-4 rounded">
+          <input
+            className="border p-2 w-full"
+            placeholder="Template Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <textarea
+            className="border p-2 w-full"
+            placeholder="Template"
+            value={promptText}
+            onChange={(e) => setPromptText(e.target.value)}
+            required
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="bg-green-600 text-white px-4 py-2 rounded"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              className="bg-gray-300 px-4 py-2 rounded"
+              onClick={() => {
+                setIsCreating(false)
+                setName('')
+                setPromptText('')
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
 
       <ul className="space-y-4">
-        {prompts.map((p) => (
-          <li key={p.id} className="border p-4 space-y-2">
-            <input
-              className="border p-2 w-full"
-              value={p.name}
-              onChange={(e) =>
-                setPrompts((prev) =>
-                  prev.map((item) =>
-                    item.id === p.id ? { ...item, name: e.target.value } : item
-                  )
-                )
-              }
-            />
-            <textarea
-              className="border p-2 w-full"
-              value={p.template}
-              onChange={(e) =>
-                setPrompts((prev) =>
-                  prev.map((item) =>
-                    item.id === p.id ? { ...item, template: e.target.value } : item
-                  )
-                )
-              }
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className="bg-green-600 text-white px-3 py-1 rounded"
-                onClick={() => handleUpdate(p)}
-              >
-                Update
-              </button>
-              <button
-                type="button"
-                className="bg-red-600 text-white px-3 py-1 rounded"
-                onClick={() => handleDelete(p.id)}
-              >
-                Delete
-              </button>
-            </div>
+        {filteredPrompts.map((p) => (
+          <li key={p.id} className="border p-4 space-y-2 rounded">
+            {editingId === p.id ? (
+              <div className="space-y-2">
+                <input
+                  className="border p-2 w-full"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  required
+                />
+                <textarea
+                  className="border p-2 w-full"
+                  value={editTemplate}
+                  onChange={(e) => setEditTemplate(e.target.value)}
+                  required
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="bg-green-600 text-white px-3 py-1 rounded"
+                    onClick={() => handleEditSave(p.id)}
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    className="bg-gray-300 px-3 py-1 rounded"
+                    onClick={() => setEditingId(null)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="font-semibold">{p.name}</div>
+                <div className="text-sm text-gray-600 whitespace-pre-wrap">
+                  {truncate(p.template)}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="bg-blue-600 text-white px-3 py-1 rounded"
+                    onClick={() => startEdit(p)}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="bg-red-600 text-white px-3 py-1 rounded"
+                    onClick={() => handleDelete(p.id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- display prompts in read-only list with truncated template and edit/delete actions
- add Create Prompt button with dedicated form
- support search/filter and inline editing

## Testing
- `npm run lint`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b033bc5c9c8333bbcad6e06b8337eb