### PR TITLE
feat: integrate DaisyUI theme and design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Sosmed Gen is a web application designed to help users generate social media pos
 * **Web Search:** Google Programmable Search Engine
 * **Deployment:** Vercel
 
+## Styling Conventions
+
+This project uses [Tailwind CSS](https://tailwindcss.com/) with the [DaisyUI](https://daisyui.com/) component library and a custom `mytheme` defined in `tailwind.config.ts`. To keep styles consistent:
+
+- Reuse the design primitives in `src/components/ui` (`Button`, `Input`, `Textarea`, `Select`) instead of ad-hoc class combinations.
+- Prefer DaisyUI component classes such as `card`, `badge`, `navbar`, and `btn` to handle colors and spacing.
+- Wrap pages with the `container` utility to maintain consistent horizontal padding.
+- When introducing new interactive elements (forms, modals, etc.), extend the `ui` component set so future changes propagate across the app.
+
 ## Environment Variables Setup
 
 To run this project, you need to create a `.env.local` file in the root directory and add the following environment variables. Obtain these keys from their respective platforms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.56.0",
+        "daisyui": "^5.0.54",
         "next": "15.5.0",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -2571,6 +2572,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/daisyui": {
+      "version": "5.0.54",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.54.tgz",
+      "integrity": "sha512-03iuq06+lLq/VczY/+YpADgLXVC1HYO63PNiH6A9hn/+f6IkVoONVc+Jh08xizkLQQCVVMMUBp+KeIdcWSBLcg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.56.0",
+    "daisyui": "^5.0.54",
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" data-theme="mytheme">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center p-4">
+    <div className="container mx-auto min-h-screen flex flex-col items-center p-4">
       <h1 className="text-3xl font-bold mt-8 mb-4">Sosmed Gen</h1>
       <p className="mb-8">
         Masukkan niche anda dan pilih gaya penulisan untuk menjana posting media sosial.

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Button from '@/components/ui/Button'
+import Textarea from '@/components/ui/Textarea'
+import Select from '@/components/ui/Select'
 
 type Task = {
   id: number
@@ -72,41 +75,36 @@ export default function PostsPage() {
   }
 
   return (
-    <div className="p-4 max-w-3xl mx-auto">
+    <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Tasks</h1>
       {tasks.map((task) => (
-        <div key={task.id} className="border p-4 mb-4 rounded">
+        <div key={task.id} className="card bg-base-100 shadow p-4 mb-4">
           {editingId === task.id ? (
             <>
               <p className="break-words">{task.videoUrl}</p>
               <p className="mt-1">Prompt: {task.prompt_id}</p>
-              <textarea
-                className="w-full rounded text-black p-2 mt-2"
+              <Textarea
+                className="mt-2"
                 value={editResult}
                 onChange={(e) => setEditResult(e.target.value)}
               />
-              <select
-                className="mt-2 p-2 rounded text-black"
+              <Select
+                className="mt-2"
                 value={editStatus}
                 onChange={(e) => setEditStatus(e.target.value)}
               >
                 <option value="draft">draft</option>
                 <option value="posted">posted</option>
-              </select>
+              </Select>
               <p className="mt-2 whitespace-pre-wrap">{task.summary}</p>
               <div className="mt-2 space-x-2">
-                <button
-                  onClick={() => handleUpdate(task.id)}
-                  className="bg-blue-600 text-white px-3 py-1 rounded"
-                >
-                  Save
-                </button>
-                <button
+                <Button onClick={() => handleUpdate(task.id)}>Save</Button>
+                <Button
                   onClick={() => setEditingId(null)}
-                  className="bg-gray-300 text-black px-3 py-1 rounded"
+                  variant="secondary"
                 >
                   Cancel
-                </button>
+                </Button>
               </div>
             </>
           ) : (
@@ -114,29 +112,27 @@ export default function PostsPage() {
               <p className="break-words">{task.videoUrl}</p>
               <p>Prompt: {task.prompt_id}</p>
               <p className="mt-2 whitespace-pre-wrap">{task.result}</p>
-              <span className="inline-block mt-2 px-2 py-1 text-sm bg-gray-200 rounded">
-                {task.status}
-              </span>
+              <span className="badge mt-2">{task.status}</span>
               <p className="mt-2 whitespace-pre-wrap">{task.summary}</p>
               <div className="mt-2 space-x-2">
-                <button
+                <Button
                   onClick={() => startEditing(task)}
-                  className="bg-yellow-500 text-white px-3 py-1 rounded"
+                  variant="warning"
                 >
                   Edit
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => handleDelete(task.id)}
-                  className="bg-red-600 text-white px-3 py-1 rounded"
+                  variant="error"
                 >
                   Delete
-                </button>
-                <button
+                </Button>
+                <Button
                   onClick={() => navigator.clipboard.writeText(task.result)}
-                  className="bg-green-600 text-white px-3 py-1 rounded"
+                  variant="success"
                 >
                   Copy
-                </button>
+                </Button>
               </div>
             </>
           )}

--- a/src/app/prompts/PromptsManager.tsx
+++ b/src/app/prompts/PromptsManager.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { useState } from 'react'
+import Button from '@/components/ui/Button'
+import Input from '@/components/ui/Input'
+import Textarea from '@/components/ui/Textarea'
 
 interface Prompt {
   id: number
@@ -55,30 +58,25 @@ export default function PromptsManager({ initialPrompts }: { initialPrompts: Pro
   return (
     <div className="space-y-6">
       <form onSubmit={handleCreate} className="space-y-2">
-        <input
-          className="border p-2 w-full"
+        <Input
           placeholder="Template Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           required
         />
-        <textarea
-          className="border p-2 w-full"
+        <Textarea
           placeholder="Template"
           value={promptText}
           onChange={(e) => setPromptText(e.target.value)}
           required
         />
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
-          Save
-        </button>
+        <Button type="submit">Save</Button>
       </form>
 
       <ul className="space-y-4">
         {prompts.map((p) => (
           <li key={p.id} className="border p-4 space-y-2">
-            <input
-              className="border p-2 w-full"
+            <Input
               value={p.name}
               onChange={(e) =>
                 setPrompts((prev) =>
@@ -88,32 +86,29 @@ export default function PromptsManager({ initialPrompts }: { initialPrompts: Pro
                 )
               }
             />
-            <textarea
-              className="border p-2 w-full"
+            <Textarea
               value={p.template}
               onChange={(e) =>
                 setPrompts((prev) =>
                   prev.map((item) =>
-                    item.id === p.id ? { ...item, template: e.target.value } : item
+                    item.id === p.id
+                      ? { ...item, template: e.target.value }
+                      : item
                   )
                 )
               }
             />
             <div className="flex gap-2">
-              <button
-                type="button"
-                className="bg-green-600 text-white px-3 py-1 rounded"
-                onClick={() => handleUpdate(p)}
-              >
+              <Button type="button" variant="success" onClick={() => handleUpdate(p)}>
                 Update
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="bg-red-600 text-white px-3 py-1 rounded"
+                variant="error"
                 onClick={() => handleDelete(p.id)}
               >
                 Delete
-              </button>
+              </Button>
             </div>
           </li>
         ))}

--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -17,8 +17,8 @@ export default async function PromptsPage() {
   const { data: prompts } = await supabase.from('prompts').select('*')
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl mb-4">Prompts</h1>
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Prompts</h1>
       <PromptsManager initialPrompts={prompts || []} />
     </div>
   )

--- a/src/components/GeneratorForm.tsx
+++ b/src/components/GeneratorForm.tsx
@@ -3,6 +3,10 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import Button from './ui/Button'
+import Input from './ui/Input'
+import Textarea from './ui/Textarea'
+import Select from './ui/Select'
 
 function extractVideoId(url: string): string | null {
   try {
@@ -143,39 +147,39 @@ export default function GeneratorForm() {
     <div className="w-full max-w-2xl mx-auto p-4">
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="videoUrl" className="block text-sm font-medium">YouTube URL</label>
-          <input
+          <label htmlFor="videoUrl" className="block text-sm font-medium">
+            YouTube URL
+          </label>
+          <Input
             type="text"
             id="videoUrl"
             value={videoUrl}
             onChange={(e) => setVideoUrl(e.target.value)}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-black p-2"
+            className="mt-1"
             placeholder="https://www.youtube.com/watch?v=example"
             required
           />
         </div>
         <div>
-          <label htmlFor="promptId" className="block text-sm font-medium">Jenis Gaya Penulisan</label>
-          <select
+          <label htmlFor="promptId" className="block text-sm font-medium">
+            Jenis Gaya Penulisan
+          </label>
+          <Select
             id="promptId"
             value={promptId ?? ''}
             onChange={(e) => setPromptId(Number(e.target.value))}
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-black p-2"
+            className="mt-1"
           >
             {prompts.map((opt) => (
               <option key={opt.id} value={opt.id}>
                 {opt.name}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
-        <button
-          type="submit"
-          disabled={isLoading}
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-        >
+        <Button type="submit" disabled={isLoading} className="w-full">
           {isLoading ? 'Menjana...' : 'Jana Teks'}
-        </button>
+        </Button>
       </form>
 
       {error && <p className="mt-4 text-red-500">{error}</p>}
@@ -183,19 +187,20 @@ export default function GeneratorForm() {
       {generatedText && (
         <div className="mt-8">
           <h3 className="text-lg font-semibold">Hasil Jana:</h3>
-          <textarea
+          <Textarea
             value={generatedText}
             onChange={(e) => setGeneratedText(e.target.value)}
-            className="mt-2 block w-full h-48 rounded-md border-gray-300 shadow-sm text-black p-2"
+            className="mt-2 h-48"
           />
           {/* BUTANG SALIN BARU DI SINI */}
-          <button
+          <Button
             type="button"
             onClick={handleCopy}
-            className="mt-2 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"
+            variant="success"
+            className="mt-2"
           >
             {isCopied ? 'Tersalin!' : 'Salin Teks'}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import Button from "./ui/Button";
 
 export default async function Navbar() {
   const supabase = await createClient();
@@ -8,30 +9,27 @@ export default async function Navbar() {
   } = await supabase.auth.getUser();
 
   return (
-    <nav className="bg-gray-800 text-white">
-      <div className="max-w-4xl mx-auto flex justify-between items-center p-4">
-        <div className="flex space-x-4">
-          <Link href="/" className="hover:underline">
+    <nav className="navbar bg-primary text-primary-content">
+      <div className="max-w-4xl mx-auto flex justify-between items-center w-full px-4">
+        <div className="flex gap-2">
+          <Link href="/" className="btn btn-ghost">
             Home
           </Link>
-          <Link href="/prompts" className="hover:underline">
+          <Link href="/prompts" className="btn btn-ghost">
             Prompts
           </Link>
           {user && (
-            <Link href="/posts" className="hover:underline">
+            <Link href="/posts" className="btn btn-ghost">
               Posts
             </Link>
           )}
         </div>
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center gap-2">
           {user && <span className="text-sm">Hello, {user.email}</span>}
           <form action="/auth/signout" method="post">
-            <button
-              type="submit"
-              className="text-sm bg-gray-600 hover:bg-gray-700 py-1 px-3 rounded"
-            >
+            <Button type="submit" variant="secondary" className="text-sm">
               Sign out
-            </button>
+            </Button>
           </form>
         </div>
       </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?:
+    | "primary"
+    | "secondary"
+    | "accent"
+    | "neutral"
+    | "info"
+    | "success"
+    | "warning"
+    | "error";
+};
+
+export default function Button({
+  variant = "primary",
+  className = "",
+  ...props
+}: ButtonProps) {
+  const base = `btn btn-${variant}`;
+  return <button className={`${base} ${className}`} {...props} />;
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Input({ className = "", ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={`input input-bordered w-full ${className}`} {...props} />;
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function Select({
+  className = "",
+  children,
+  ...props
+}: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select className={`select select-bordered w-full ${className}`} {...props}>
+      {children}
+    </select>
+  );
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function Textarea({
+  className = "",
+  ...props
+}: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      className={`textarea textarea-bordered w-full ${className}`}
+      {...props}
+    />
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "tailwindcss";
+import daisyui from "daisyui";
+
+export default {
+  content: ["./src/**/*.{js,ts,jsx,tsx}", "./src/app/**/*.{js,ts,jsx,tsx}"],
+  plugins: [daisyui],
+  daisyui: {
+    themes: [
+      {
+        mytheme: {
+          primary: "#2563eb",
+          secondary: "#6b7280",
+          accent: "#16a34a",
+          neutral: "#1f2937",
+          "base-100": "#ffffff",
+          info: "#3abff8",
+          success: "#36d399",
+          warning: "#fbbd23",
+          error: "#f87272",
+        },
+      },
+      "dark",
+    ],
+  },
+} satisfies Config;


### PR DESCRIPTION
## Summary
- add DaisyUI with custom `mytheme` and enable in layout
- replace ad-hoc styling with reusable Button/Input/etc components across app
- document styling conventions for future contributions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b033bd425c8333b5aac303654f78e2