### PR TITLE
feat: default button type

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,18 @@
+import { ButtonHTMLAttributes } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary";
+}
+
+export function Button({ variant = "primary", type = "button", className = "", ...props }: ButtonProps) {
+  const variantClass =
+    variant === "secondary"
+      ? "bg-gray-200 text-gray-900"
+      : "bg-blue-600 text-white";
+
+  return (
+    <button type={type} className={`${variantClass} ${className}`} {...props} />
+  );
+}
+
+export default Button;


### PR DESCRIPTION
## Summary
- add reusable `Button` component that defaults to type="button" to avoid unintended form submissions

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b039b3a1ac833393b0c972c5905a4e