### PR TITLE
feat: support refs on basic form components

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ type = "button", ...props }, ref) => (
+    <button type={type} ref={ref} {...props} />
+  )
+)
+Button.displayName = "Button"
+
+export default Button

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ type = "text", ...props }, ref) => (
+    <input type={type} ref={ref} {...props} />
+  )
+)
+Input.displayName = "Input"
+
+export default Input

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  (props, ref) => (
+    <select ref={ref} {...props} />
+  )
+)
+Select.displayName = "Select"
+
+export default Select

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (props, ref) => (
+    <textarea ref={ref} {...props} />
+  )
+)
+Textarea.displayName = "Textarea"
+
+export default Textarea


### PR DESCRIPTION
## Summary
- add forwardRef-based UI primitives: Input, Select, Textarea, Button
- default type="text" for Input and type="button" for Button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b039b4bc1c8333a707b54943c1a788